### PR TITLE
Use .dev TLD @ future-of-cherrypy-bright-and-shiny

### DIFF
--- a/article/future-of-cherrypy-bright-and-shiny.html
+++ b/article/future-of-cherrypy-bright-and-shiny.html
@@ -359,7 +359,7 @@ the case needs small constant improment and&nbsp;polishing.</p>
 <table class="docutils footnote" frame="void" id="id32" rules="none">
 <colgroup><col class="label" /><col /></colgroup>
 <tbody valign="top">
-<tr><td class="label">[1]</td><td><em>(<a class="fn-backref" href="#id1">1</a>, <a class="fn-backref" href="#id15">2</a>)</em> <a class="reference external" href="http://cherrypy.org/">http://cherrypy.org/</a></td></tr>
+<tr><td class="label">[1]</td><td><em>(<a class="fn-backref" href="#id1">1</a>, <a class="fn-backref" href="#id15">2</a>)</em> <a class="reference external" href="https://cherrypy.dev">https://cherrypy.dev</a></td></tr>
 </tbody>
 </table>
 <table class="docutils footnote" frame="void" id="id33" rules="none">


### PR DESCRIPTION
We've lost the old domain and the current website is https://cherrypy.dev https://github.com/cherrypy/cherrypy/issues/1872#issuecomment-915207591